### PR TITLE
Fix a syntax typo preventing the example running

### DIFF
--- a/11_notebooks/jupyter_inside_modal.py
+++ b/11_notebooks/jupyter_inside_modal.py
@@ -52,7 +52,7 @@ def seed_volume():
 
 
 @stub.function(
-    concurrency_limit=1, network_file_systems={CACHE_DIR: volume}, timeout=1_500
+    concurrency_limit=1, network_file_systems={CACHE_DIR: volume}, timeout=1500
 )
 def run_jupyter(timeout: int):
     jupyter_process = subprocess.Popen(


### PR DESCRIPTION

### Type of Change

- [ ] New Example
- [ ] Example updates (Bug fixes, new features, etc.)
- [x] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.

## Outside contributors

You're great! Thanks for your contribution.
